### PR TITLE
Make token optional

### DIFF
--- a/src/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/app.py
+++ b/src/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/app.py
@@ -17,10 +17,10 @@ from stac_fastapi.sqlalchemy.session import Session
 from stac_fastapi.sqlalchemy.types.search import SQLAlchemySTACSearch
 
 
-def must_have_token_query_param(
+def token_query_param(
     token: str = Depends(security.api_key.APIKeyQuery(name="token", auto_error=False)),
 ):
-    """This defines a required api-key query param named 'token'"""
+    """This defines an api-key query param named 'token'"""
     # Set auto_error to `True` to make `token `required.
     pass
 
@@ -60,9 +60,7 @@ api = StacApi(
         landing_page_id="dataforsyningen-flyfotoapi",
     ),
     search_request_model=SQLAlchemySTACSearch,
-    route_dependencies=[
-        (ROUTES_REQUIRING_TOKEN, [Depends(must_have_token_query_param)])
-    ],
+    route_dependencies=[(ROUTES_REQUIRING_TOKEN, [Depends(token_query_param)])],
 )
 app = api.app
 

--- a/src/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/src/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -120,7 +120,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
         )
 
     def href_builder(self, **kwargs) -> BaseHrefBuilder:
-        """Override with HrefBuilder which adds API token to all hrefs"""
+        """Override with HrefBuilder which adds API token to all hrefs if present"""
         request = kwargs["request"]
         base_url = str(request.base_url)
         token = request.query_params.get("token")

--- a/src/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/types/links.py
+++ b/src/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/types/links.py
@@ -12,5 +12,6 @@ class ApiTokenHrefBuilder(BaseHrefBuilder):
 
     def build(self, path: str = None, query: Dict[str, str] = None):
         q = query or {}
-        q["token"] = self.token
+        if self.token:
+            q["token"] = self.token
         return super().build(path=path, query=q)

--- a/src/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/src/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -316,24 +316,7 @@ def test_filter_queryables_single_collection(app_client, load_test_data):
 #    assert len(resp_json["properties"]) == len(shared_queryables)
 
 
-def test_app_path_requiring_token_fails_if_no_token(
-    load_test_data, token_app_client, postgres_transactions
-):
-    item = load_test_data("test_item.json")
-    postgres_transactions.create_item(item, request=MockStarletteRequest)
-
-    for route in STAC_ROUTES_REQUIRING_TOKEN:
-        path = route["path"]
-        if route["method"] == "GET":
-            resp = token_app_client.get(path)
-        else:
-            resp = token_app_client.post(path, json={})
-        assert (
-            resp.status_code == 403
-        ), f"{route['method']} {path} should fail when missing token"
-
-
-def test_app_path_requiring_token_should_return_links_with_token(
+def test_app_path_allowing_token_should_return_links_with_token(
     load_test_data, token_app_client, postgres_transactions
 ):
     item = load_test_data("test_item.json")

--- a/src/stac_fastapi/sqlalchemy/tests/conftest.py
+++ b/src/stac_fastapi/sqlalchemy/tests/conftest.py
@@ -28,7 +28,7 @@ from stac_fastapi.sqlalchemy.core import CoreCrudClient, CoreFiltersClient
 from stac_fastapi.sqlalchemy.models import database
 from stac_fastapi.sqlalchemy.session import Session
 from stac_fastapi.sqlalchemy.app import (
-    must_have_token_query_param,
+    token_query_param,
     ROUTES_REQUIRING_TOKEN,
 )
 
@@ -317,7 +317,7 @@ def token_app_client(api_client):
     """Gets a TestClient with an app that requires `token` for some paths"""
     api_client.add_route_dependencies(
         scopes=ROUTES_REQUIRING_TOKEN,
-        dependencies=[Depends(must_have_token_query_param)],
+        dependencies=[Depends(token_query_param)],
     )
     with TestClient(api_client.app) as test_app:
         yield test_app


### PR DESCRIPTION
According to #3 

If client puts API token in header the API acts as if it doesnt know anything about tokens.

If token is in a URL parameter then API adds the token to all returned URLs.