### PR TITLE
fjernet end_datetime fra queryables (da den ikke er udstillet i resul…

### DIFF
--- a/src/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/config.py
+++ b/src/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/config.py
@@ -54,10 +54,10 @@ class BaseQueryables(str, AutoValueEnum):
 
 
 class SkraafotosProperties(str, AutoValueEnum):
-    end_datetime = auto()
-    easting = auto()
-    northing = auto()
-    height = auto()
+    # end_datetime = auto()
+    easting = "pers:perspective_center.x"
+    northing = "pers:perspective_center.y"
+    height = "pers:perspective_center.z"
     vertical_crs = "pers:vertical_crs"
     horisontal_crs = "pers:crs"
     omega = "pers:omega"
@@ -68,7 +68,7 @@ class SkraafotosProperties(str, AutoValueEnum):
     azimuth = "view:azimuth"
     offnadir = "view:off_nadir"
     estacc = "estimated_accuracy"
-    producer = auto()
+    producer = "providers.producer"
     gsd = auto()
     # license = auto()
     camera_id = "instruments"
@@ -124,12 +124,12 @@ class QueryableInfo:
     # )
 
     # properties types: Pygeofilter currently don't support array operations in their sqlalchemy backend, so Array queryables are not exposed
-    end_datetime = (
-        None,
-        "string",
-        "End datetime",
-        None,
-    )
+    # end_datetime = (
+    #     None,
+    #     "string",
+    #     "End datetime",
+    #     None,
+    # )
     easting = (
         None,
         "number",
@@ -171,7 +171,7 @@ class QueryableInfo:
     producer = (
         None,
         "string",
-        "Producer name",
+        "(Providers) Producer name",
         None,
     )
     gsd = (


### PR DESCRIPTION
…tat json), samt renamet easting, northing, height queryable navne til pers:perspective_center.x/y/z

tilføjet queryable test der sikrer at queryable enums er i sync med dens queryableInfo samt de udstillede peroperty navne. Tilføjet test der tjekker at /queryables endpoint returner intersectionen af alle individuelle collections queryables